### PR TITLE
Smoother deceleration

### DIFF
--- a/src/main/java/com/github/vini2003/linkart/mixin/AbstractMinecartEntityMixin.java
+++ b/src/main/java/com/github/vini2003/linkart/mixin/AbstractMinecartEntityMixin.java
@@ -68,7 +68,8 @@ public abstract class AbstractMinecartEntityMixin extends Entity implements Link
                 vec3d.multiply(Linkart.CONFIG.velocityMultiplier);
 
                 if (dist <= 1) {
-                    setVelocity(vec3d.multiply(dist * 0.3));
+                    // Go slower (1.0->0.8) the closer (1->0) we are
+                    setVelocity(vec3d.multiply(0.8 + 0.2*Math.abs(dist)));
                 } else {
                     if (dist <= Linkart.CONFIG.pathfindingDistance) {
                         setVelocity(vec3d);


### PR DESCRIPTION
The way [this Audaki Cart Engine patch](https://github.com/audaki/minecraft-cart-engine/pull/23) detects whether it's safe to accelerate more is by checking if all carts have approximately the same speed as the leading cart. The issue is that this may never happen without this patch.

Currently, if the cart is within 1m of the cart ahead, the velocity is multiplied by 0.3. At a high enough speed (such as with Audaki Cart Engine), this means a cart could be within 1m in one tick (and have a slower velocity), on the next tick be outside 1m (and have normal velocity), on the next tick be inside 1m, repeatedly.

The patch makes carts smoothly slow down to 0.8 of the normal velocity depending on the distance so carts won't have an unstable velocity.