### PR TITLE
Stop the cart when link is broken

### DIFF
--- a/src/main/java/com/github/vini2003/linkart/mixin/AbstractMinecartEntityMixin.java
+++ b/src/main/java/com/github/vini2003/linkart/mixin/AbstractMinecartEntityMixin.java
@@ -94,6 +94,7 @@ public abstract class AbstractMinecartEntityMixin extends Entity implements Link
 
         duck.linkart$setFollower(null);
         linkart$setFollowing(null);
+        setVelocity(0, 0, 0);
 
         ItemEntity itemEntity = new ItemEntity(getWorld(), getX(), getY(), getZ(), Items.CHAIN.getDefaultStack());
         itemEntity.setToDefaultPickupDelay();


### PR DESCRIPTION
This is mostly to help compatibility with Audaki Cart Engine when trains break apart mid journey at high speeds. Stopping the cart prevents two trains going the same way and makes cleaning up easier.