### PR TITLE
Ensure train carts don't reverse on sharp curves

### DIFF
--- a/src/main/java/com/github/vini2003/linkart/mixin/AbstractMinecartEntityMixin.java
+++ b/src/main/java/com/github/vini2003/linkart/mixin/AbstractMinecartEntityMixin.java
@@ -65,6 +65,25 @@ public abstract class AbstractMinecartEntityMixin extends Entity implements Link
                 Vec3d pos2 = linkart$getFollowing().getPos();
                 double dist = Math.abs(pos.distanceTo(pos2)) - 1.2;
                 Vec3d vec3d = pos.relativize(pos2);
+
+                // Check if we are on a sharp curve
+                Vec3d vel = getVelocity();
+                Vec3d vel2 = linkart$getFollowing().getVelocity();
+                boolean differentDirection = (
+                    vel.length() > 0.15
+                    && vel2.length() > 0.005
+                    && vel.normalize().distanceTo(vel2.normalize()) > 1.42
+                    && pos.distanceTo(pos2) > 0.5
+                );
+
+                if (differentDirection) {
+                    // Keep ourselves going at same speed if on curve
+                    dist += 1.2;
+                    vec3d = vel;
+                }
+
+                // Calculate new velocity
+                vec3d = vec3d.normalize().multiply(dist);
                 vec3d.multiply(Linkart.CONFIG.velocityMultiplier);
 
                 if (dist <= 1) {


### PR DESCRIPTION
The patch makes trains consistently go around curves with at least one straight track between turns. Trains can sometimes traverse even sharper curves but it's not guaranteed (and honestly I have no clue how to make it consistently work).