### PR TITLE
Change default chunkloadingRadius to 3

### DIFF
--- a/src/main/java/com/github/vini2003/linkart/configuration/LinkartConfiguration.java
+++ b/src/main/java/com/github/vini2003/linkart/configuration/LinkartConfiguration.java
@@ -5,5 +5,5 @@ public class LinkartConfiguration {
     public float velocityMultiplier = 1F;
     public int collisionDepth = 8;
     public boolean chunkloading = false;
-    public int chunkloadingRadius = 2;
+    public int chunkloadingRadius = 3;
 }


### PR DESCRIPTION
Values below 2 don't seem to load the chunk properly (maybe something to do with chunk load types) and so don't move the minecart train through faraway chunks.
